### PR TITLE
fix: different token for each unique function

### DIFF
--- a/utils/getToken.js
+++ b/utils/getToken.js
@@ -100,12 +100,13 @@ const getTokenCreator = (options) => {
     const getAndSaveNewToken = async () => {
         return (await redisResponse()) ? (await redisResponse()) : (await spikeResponse()) ? (await spikeResponse()) : (await getAndSaveNewToken());
     }
+    
+    let token
 
     async function getToken() {
-        let token = this.token || null;
         if (await isValid(token))
             return token;
-        this.token = await getAndSaveNewToken();
+        token = await getAndSaveNewToken();
         return this.token;
     }
 


### PR DESCRIPTION
There should be a different token in each` getToken` function.
When you used `this.token` before, it took the `this` of the scope which called `getTokenCreator`.
In my case, because I call `getTokenCreator` from the same place each time (that's where I imported it), `this.token` will stay the same in all the `getToken` functions that I will create.

This fix solves the problem. I think you could alternatively create an object that wraps the function...